### PR TITLE
@types/ws 8.5.4 버전 typescript generic 관련 충돌 문제

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/async": "^3.2.20",
         "@types/body-parser": "^1.19.2",
         "@types/deasync": "^0.1.2",
-        "@types/ws": "^8.5.13",
+        "@types/ws": "8.5.4",
         "async": "^3.2.4",
         "axios": "^1.4.0",
         "body-parser": "^1.20.2",
@@ -1247,9 +1247,7 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
-      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
+      "version": "8.5.4",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8065,8 +8063,6 @@
     },
     "node_modules/ws": {
       "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -8164,7 +8160,8 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0",
-        "deasync": "^0.1.30"
+        "deasync": "^0.1.30",
+        "ws": "^8.18.0"
       }
     },
     "packages/bots/slack": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/async": "^3.2.20",
     "@types/body-parser": "^1.19.2",
     "@types/deasync": "^0.1.2",
-    "@types/ws": "^8.5.13",
+    "@types/ws": "8.5.4",
     "async": "^3.2.4",
     "axios": "^1.4.0",
     "body-parser": "^1.20.2",

--- a/packages/bots/mattermost/package.json
+++ b/packages/bots/mattermost/package.json
@@ -15,8 +15,6 @@
   "dependencies": {
     "axios": "^1.4.0",
     "deasync": "^0.1.30",
-    "@types/ws": "^8.5.13",
-    "@types/deasync": "^0.1.2",
     "ws": "^8.18.0"
   },
   "version": "0.0.11",


### PR DESCRIPTION
@types/ws 8.5.4 버전 이후에 typescript generic 관련 충돌 문제가 있음 -> 해당 모듈을 수정될 때까지 v8.5.4로 고정